### PR TITLE
fix(charts): fix in-cluster test setup via helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Setting the `GINKGO_NODES` environment variable to a value of `1` will allow ser
 If you have Go 1.5 or greater already installed and working properly and also have the [Glide](https://github.com/Masterminds/glide) dependency management tool for Go installed, you may clone this repository into your `$GOPATH`:
 
 ```console
-git clone git@github.com:deis/workflow-e2e.git $GOPATH/src/github.com/deis/workflow-e2e
+git clone git@github.com:teamhephy/workflow-e2e.git $GOPATH/src/github.com/deis/workflow-e2e
 ```
 
 One-time execution of the following will resolve the test suite's own dependencies:
@@ -101,7 +101,7 @@ If you do not have Go 1.5 or greater installed locally, but do have a Docker dae
 In this case, you may clone this repository into a path of your own choosing (does not need to be on your `$GOPATH`):
 
 ```console
-git clone git@github.com:deis/workflow-e2e.git /path/of/your/choice
+git clone git@github.com:teamhephy/workflow-e2e.git /path/of/your/choice
 ```
 
 Then build the test image and execute the test suite:
@@ -117,7 +117,7 @@ A third option is to run the test suite from within the very cluster that is und
 To install the [helm](https://github.com/kubernetes/helm) chart and start the tests, assuming helm and its corresponding server component tiller are [installed](https://github.com/kubernetes/helm/blob/master/docs/install.md):
 
 ```console
-git clone git clone git@github.com:deis/workflow-e2e.git; cd workflow-e2e
+git clone git clone git@github.com:teamhephy/workflow-e2e.git; cd workflow-e2e
 helm dependency update charts/workflow-e2e
 helm upgrade --install workflow-e2e charts/workflow-e2e --namespace deis
 ```

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ A third option is to run the test suite from within the very cluster that is und
 To install the [helm](https://github.com/kubernetes/helm) chart and start the tests, assuming helm and its corresponding server component tiller are [installed](https://github.com/kubernetes/helm/blob/master/docs/install.md):
 
 ```console
-helm repo add workflow-e2e https://charts.deis.com/workflow-e2e
-helm install --verify workflow-e2e/workflow-e2e --namespace deis
+git clone git clone git@github.com:deis/workflow-e2e.git; cd workflow-e2e
+helm dependency update charts/workflow-e2e
+helm upgrade --install workflow-e2e charts/workflow-e2e --namespace deis
 ```
 
 To monitor tests as they execute:

--- a/charts/workflow-e2e/templates/workflow-e2e-pod.yaml
+++ b/charts/workflow-e2e/templates/workflow-e2e-pod.yaml
@@ -11,6 +11,8 @@ spec:
     image: {{.Values.org}}/workflow-e2e:{{.Values.docker_tag}}
     imagePullPolicy: {{.Values.pull_policy}}
     env:
+      - name: DEIS_ROUTER_SERVICE_PORT
+        value: "80"
       - name: GINKGO_NODES
         value: "{{.Values.ginkgo_nodes}}"
       - name: JUNIT
@@ -22,6 +24,14 @@ spec:
         value: "{{.Values.test}}"
       - name: DEBUG_MODE
         value: "{{.Values.debug_mode}}"
+    command: ["/bin/bash"]
+    args:
+        - -c
+        - >
+            export DEIS_CONTROLLER_URL=http://deis.$$(getent hosts deis-router | grep -o "^[^ ]*").nip.io;
+            export DEIS_ROUTER_SERVICE_HOST=deis.$$(getent hosts deis-router | grep -o "^[^ ]*").nip.io;
+            ./docker-test-integration.sh
+
     volumeMounts:
     - name: artifact-volume
       mountPath: /root


### PR DESCRIPTION
* removed the `helm repo add` from the README because I think this chart isn't actually hosted anywhere currently(?)
* and then, there's some hackery in the actual pod spec, which should mean that you only need to deploy this into the same namespace as hephy and it'll just work™️, no matter how the external DNS is set up (or whether it's set up at all). However, this probably only works with deis-router, not with the experimental native ingress.